### PR TITLE
Bump upper bound for alex-tools

### DIFF
--- a/layout-rules.cabal
+++ b/layout-rules.cabal
@@ -23,7 +23,7 @@ source-repository head
 library
   exposed-modules:     Text.Layout.OffSides
   build-depends:       base >=4.7 && < 5,
-                       alex-tools >= 0.3 && < 0.4,
+                       alex-tools >= 0.3 && < 0.5,
                        text >= 1.2 && < 1.3
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Raises the upper bound of `alex-tools` to work with the latest version on Hackage. 
http://hackage.haskell.org/package/alex-tools-0.4